### PR TITLE
Remove the deprecated 'enabledForSite' param

### DIFF
--- a/src/services/XmlSitemap.php
+++ b/src/services/XmlSitemap.php
@@ -167,10 +167,11 @@ class XmlSitemap extends Component
                     $query->offset($offset);
                     $query->limit($totalElementsPerSitemap);
                     $query->site($site);
-                    $query->enabledForSite();
 
                     if ($urlEnabledSectionType->getElementLiveStatus()) {
                         $query->status($urlEnabledSectionType->getElementLiveStatus());
+                    }else {
+                        $query->status(Element::STATUS_ENABLED);
                     }
 
                     if ($sitemapKey === 'singles') {


### PR DESCRIPTION
The parameter should be removed as this throws an deprecation error in craft 3.5